### PR TITLE
Deny all requests to `xmlrpc.php`

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ Add this role to `requirements.yml`:
 ```yaml
 # requirements.yml
 - src: https://github.com/ItinerisLtd/trellis-disable-xml-rpc
-  version: 0.1.0 # Check for latest version!
+  version: 0.2.0 # Check for latest version!
 ```
 
 Run the command:

--- a/templates/disable-xml-rpc.conf.j2
+++ b/templates/disable-xml-rpc.conf.j2
@@ -3,6 +3,6 @@
 # trellis-disable-xml-rpc
 # https://github.com/ItinerisLtd/trellis-disable-xml-rpc
 
-location ^~ /wp/xmlrpc.php {
+location ~* xmlrpc\.php$ {
   return 444;
 }


### PR DESCRIPTION
Before:

- `/wp/xmlrpc.php` ==> 444
- `/xmlrpc.php` ==> 404
- `/xyz/xmlrpc.php` ==> 404
- case sensitive

After:

- `/wp/xmlrpc.php` ==> 444
- `/xmlrpc.php` ==> 444
- `/xyz/xmlrpc.php` ==> 444
- case insensitive

Why?

Because spam bots don't care you are using Bedrock or not.